### PR TITLE
Added an option to specify device index for rtl_fm

### DIFF
--- a/pymultimonaprs.json
+++ b/pymultimonaprs.json
@@ -7,7 +7,8 @@
 	"rtl": {
 		"freq": 144.800,
 		"ppm": 0,
-		"gain": 0
+		"gain": 0,
+		"device_index": 0
 	},
 	"alsa": {
 		"device": "default"

--- a/pymultimonaprs/multimon.py
+++ b/pymultimonaprs/multimon.py
@@ -31,7 +31,8 @@ class Multimon:
 			if self.config['source'] == 'rtl':
 				proc_src = subprocess.Popen(
 					['rtl_fm', '-f', str(int(self.config['rtl']['freq'] * 1e6)), '-s', '22050',
-					'-p', str(self.config['rtl']['ppm']), '-g', str(self.config['rtl']['gain']), '-'],
+					'-p', str(self.config['rtl']['ppm']), '-g', str(self.config['rtl']['gain']), 
+					'-d', str(self.config['rtl']['device_index']), '-'],
 					stdout=subprocess.PIPE, stderr=open('/dev/null')
 				)
 			elif self.config['source'] == 'alsa':


### PR DESCRIPTION
If multiple RTL devices are installed pymultimonaprs always defaults to
the device at index 0. I have added an option to the config file and updated the source code to implement that.
