### PR TITLE
add debug option to json file to log DEBUG into syslog

### DIFF
--- a/bin/pymultimonaprs
+++ b/bin/pymultimonaprs
@@ -23,7 +23,7 @@ args = parser.parse_args()
 config = json.load(open(args.config))
 
 logger = logging.getLogger('pymultimonaprs')
-loglevel = logging.DEBUG if args.verbose else logging.INFO
+loglevel = logging.DEBUG if (int(config['rtl']['debug'] == 1)) else logging.INFO
 logger.setLevel(loglevel)
 if args.syslog:
 	loghandler = logging.handlers.SysLogHandler(address = '/dev/log')

--- a/pymultimonaprs.json
+++ b/pymultimonaprs.json
@@ -9,7 +9,8 @@
 		"ppm": 0,
 		"gain": 0,
 		"offset_tuning": false,
-		"device_index": 0
+		"device_index": 0,
+		"debug": 0,
 	},
 	"alsa": {
 		"device": "default"


### PR DESCRIPTION
wanted to be able to log DEBUG to syslog since it's more interesting.

setting debug to 1 in the json file will activate that feature. 0 is off obviously.