### PR TITLE
Add support for multiple internet APRS gateways, retain configuration compatibility

### DIFF
--- a/pymultimonaprs.json
+++ b/pymultimonaprs.json
@@ -1,7 +1,7 @@
 {
 	"callsign": "DL0ABC-1",
 	"passcode": "12345",
-	"gateway": "euro.aprs2.net:14580",
+	"gateway": ["euro.aprs2.net:14580","noam.aprs2.net:14580"],
 	"append_callsign": true,
 	"source": "rtl",
 	"rtl": {

--- a/pymultimonaprs/gate.py
+++ b/pymultimonaprs/gate.py
@@ -8,13 +8,13 @@ import sys
 import logging
 import select
 import errno
+import itertools
 from time import sleep
 
 class IGate:
-	def __init__(self, callsign, passcode, gateway):
+	def __init__(self, callsign, passcode, gateways):
 		self.log = logging.getLogger('pymultimonaprs')
-		self.server, self.port = gateway.split(':')
-		self.port = int(self.port)
+		self.gateways = itertools.cycle(gateways)
 		self.callsign = callsign
 		self.passcode = passcode
 		self.socket = None
@@ -35,6 +35,9 @@ class IGate:
 			try:
 				# Connect
 				self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+				gateway = next(self.gateways)
+				self.server, self.port = gateway.split(':')
+				self.port = int(self.port)
 				ip = socket.gethostbyname(self.server)
 				self.log.info("connecting... %s:%i" % (ip, self.port))
 				self.socket.connect((ip, self.port))
@@ -59,7 +62,7 @@ class IGate:
 
 				connected = True
 			except socket.error as e:
-				self.log.warn("Error when connecting to server: '%s'" % str(e))
+				self.log.warn("Error when connecting to %s:%d: '%s'" % (self.server,self.port,str(e)))
 				sleep(1)
 
 	def _disconnect(self):

--- a/pymultimonaprs/gate.py
+++ b/pymultimonaprs/gate.py
@@ -14,7 +14,11 @@ from time import sleep
 class IGate:
 	def __init__(self, callsign, passcode, gateways):
 		self.log = logging.getLogger('pymultimonaprs')
-		self.gateways = itertools.cycle(gateways)
+		if type(gateways) is list:
+			self.gateways = itertools.cycle(gateways)
+			self.gateway = False
+		else:
+			self.gateway = gateways #old config, single hostname as a string
 		self.callsign = callsign
 		self.passcode = passcode
 		self.socket = None
@@ -35,7 +39,7 @@ class IGate:
 			try:
 				# Connect
 				self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-				gateway = next(self.gateways)
+				gateway = self.gateway or next(self.gateways)
 				self.server, self.port = gateway.split(':')
 				self.port = int(self.port)
 				ip = socket.gethostbyname(self.server)


### PR DESCRIPTION
Without breaking compatibility of previous configurations, allow multiple internet APRS gateways to be specified in the config file as an array of strings. Uses `itertools.cycle()` to continuously loop over the list, in order, until a connection is made.
Feature requested by @mmiller7 , asdil12/pymultimonaprs#18