### PR TITLE
Ipv6 support

### DIFF
--- a/bin/pymultimonaprs
+++ b/bin/pymultimonaprs
@@ -91,8 +91,15 @@ def bc():
 		sleep(config['beacon']['send_every'])
 
 logger.info("Starting pymultimonaprs")
+				
+if 'prefered_protocol' in config:
+	prefered_protocol = config['prefered_protocol'].lower()
+else:
+	# Keep old behavior with ipv4 only if nothing specified
+	prefered_protocol = 'ipv4'
+	logger.info("Prefered protocol not specified, fallback to only IPv4")
 
-ig = IGate(config['callsign'], config['passcode'], config['gateway'])
+ig = IGate(config['callsign'], config['passcode'], config['gateway'], prefered_protocol)
 mm = Multimon(mmcb,config)
 
 def signal_handler(signal, frame):

--- a/bin/pymultimonaprs
+++ b/bin/pymultimonaprs
@@ -92,14 +92,14 @@ def bc():
 
 logger.info("Starting pymultimonaprs")
 				
-if 'prefered_protocol' in config:
-	prefered_protocol = config['prefered_protocol'].lower()
+if 'preferred_protocol' in config:
+	preferred_protocol = config['preferred_protocol'].lower()
 else:
 	# Keep old behavior with ipv4 only if nothing specified
-	prefered_protocol = 'ipv4'
-	logger.info("Prefered protocol not specified, fallback to only IPv4")
+	preferred_protocol = 'ipv4'
+	logger.info("Preferred protocol not specified, fallback to only IPv4")
 
-ig = IGate(config['callsign'], config['passcode'], config['gateway'], prefered_protocol)
+ig = IGate(config['callsign'], config['passcode'], config['gateway'], preferred_protocol)
 mm = Multimon(mmcb,config)
 
 def signal_handler(signal, frame):

--- a/bin/pymultimonaprs
+++ b/bin/pymultimonaprs
@@ -91,13 +91,8 @@ def bc():
 		sleep(config['beacon']['send_every'])
 
 logger.info("Starting pymultimonaprs")
-				
-if 'preferred_protocol' in config:
-	preferred_protocol = config['preferred_protocol'].lower()
-else:
-	# Keep old behavior with ipv4 only if nothing specified
-	preferred_protocol = 'ipv4'
-	logger.info("Preferred protocol not specified, fallback to only IPv4")
+
+preferred_protocol = config.get("preferred_protocol", "any").lower()
 
 ig = IGate(config['callsign'], config['passcode'], config['gateway'], preferred_protocol)
 mm = Multimon(mmcb,config)

--- a/pymultimonaprs.json
+++ b/pymultimonaprs.json
@@ -2,6 +2,7 @@
 	"callsign": "DL0ABC-1",
 	"passcode": "12345",
 	"gateway": ["euro.aprs2.net:14580","noam.aprs2.net:14580"],
+	"preferred_protocol": "any",
 	"append_callsign": true,
 	"source": "rtl",
 	"rtl": {

--- a/pymultimonaprs/gate.py
+++ b/pymultimonaprs/gate.py
@@ -12,7 +12,7 @@ import itertools
 from time import sleep
 
 class IGate:
-	def __init__(self, callsign, passcode, gateways):
+	def __init__(self, callsign, passcode, gateways, prefered_protocol):
 		self.log = logging.getLogger('pymultimonaprs')
 		if type(gateways) is list:
 			self.gateways = itertools.cycle(gateways)
@@ -21,6 +21,7 @@ class IGate:
 			self.gateway = gateways #old config, single hostname as a string
 		self.callsign = callsign
 		self.passcode = passcode
+		self.prefered_protocol = prefered_protocol
 		self.socket = None
 		self._sending_queue = Queue.Queue(maxsize=1)
 		self._connect()
@@ -41,7 +42,14 @@ class IGate:
 				gateway = self.gateway or next(self.gateways)
 				self.server, self.port = gateway.split(':')
 				self.port = int(self.port)
-				addrinfo = socket.getaddrinfo(self.server, self.port)#, socket.AF_INET6/AF_INET)
+				
+				if self.prefered_protocol == 'ipv6':
+					addrinfo = socket.getaddrinfo(self.server, self.port, socket.AF_INET6)
+				elif self.prefered_protocol == 'ipv4':
+					addrinfo = socket.getaddrinfo(self.server, self.port, socket.AF_INET)
+				else:
+					addrinfo = socket.getaddrinfo(self.server, self.port)
+					
 				self.socket = socket.socket(*addrinfo[0][0:3])
 				self.log.info("connecting... %s:%i" % (addrinfo[0][4], self.port))
 				self.socket.connect(addrinfo[0][4])

--- a/pymultimonaprs/gate.py
+++ b/pymultimonaprs/gate.py
@@ -12,7 +12,7 @@ import itertools
 from time import sleep
 
 class IGate:
-	def __init__(self, callsign, passcode, gateways, prefered_protocol):
+	def __init__(self, callsign, passcode, gateways, preferred_protocol):
 		self.log = logging.getLogger('pymultimonaprs')
 		if type(gateways) is list:
 			self.gateways = itertools.cycle(gateways)
@@ -21,7 +21,7 @@ class IGate:
 			self.gateway = gateways #old config, single hostname as a string
 		self.callsign = callsign
 		self.passcode = passcode
-		self.prefered_protocol = prefered_protocol
+		self.preferred_protocol = preferred_protocol
 		self.socket = None
 		self._sending_queue = Queue.Queue(maxsize=1)
 		self._connect()
@@ -43,9 +43,9 @@ class IGate:
 				self.server, self.port = gateway.split(':')
 				self.port = int(self.port)
 				
-				if self.prefered_protocol == 'ipv6':
+				if self.preferred_protocol == 'ipv6':
 					addrinfo = socket.getaddrinfo(self.server, self.port, socket.AF_INET6)
-				elif self.prefered_protocol == 'ipv4':
+				elif self.preferred_protocol == 'ipv4':
 					addrinfo = socket.getaddrinfo(self.server, self.port, socket.AF_INET)
 				else:
 					addrinfo = socket.getaddrinfo(self.server, self.port)

--- a/pymultimonaprs/gate.py
+++ b/pymultimonaprs/gate.py
@@ -38,13 +38,13 @@ class IGate:
 		while not connected:
 			try:
 				# Connect
-				self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 				gateway = self.gateway or next(self.gateways)
 				self.server, self.port = gateway.split(':')
 				self.port = int(self.port)
-				ip = socket.gethostbyname(self.server)
-				self.log.info("connecting... %s:%i" % (ip, self.port))
-				self.socket.connect((ip, self.port))
+				addrinfo = socket.getaddrinfo(self.server, self.port)#, socket.AF_INET6/AF_INET)
+				self.socket = socket.socket(*addrinfo[0][0:3])
+				self.log.info("connecting... %s:%i" % (addrinfo[0][4], self.port))
+				self.socket.connect(addrinfo[0][4])
 				self.log.info("connected")
 
 				server_hello = self.socket.recv(1024)


### PR DESCRIPTION
Added support for IPv6.

To select IPv4/IPv6 as preferred protocol you must set in json config file:
 - "preferred_protocol": "ipv4" to force IPv4
 - "preferred_protocol": "ipv6" to force IPv6
 - "preferred_protocol": "any" (default) to take protocol preferred by server (first protocol returned by DNS). Will take IPv4 if no IPv6 connection available.