### PR TITLE
corrected wrong path for executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ class post_install(install):
 
 setup(
 	name='pymultimonaprs',
-	version='1.1.1',
+	version='1.2.0',
 	license='GPL',
 	description='RF2APRS-IG Gateway',
 	author='Dominik Heidler',


### PR DESCRIPTION
on debian the executable residents in /usr/local/bin/pymultimonaprs

sudo 'systemctl enable pymultimonaprs' have to be executed